### PR TITLE
Fix alias to Nevu's Show Global Glyphs

### DIFF
--- a/GlyphsScriptsConfi.sh
+++ b/GlyphsScriptsConfi.sh
@@ -903,12 +903,12 @@ echo '========================================'
 echo 'Done mekkablue ShowTopsAndBottoms Plugin'
 echo '========================================'
 
-git clone https://github.com/Nevu/PluginsForGlyphs_Nevu.git Nevu_Plugins
-cd Nevu_Plugins/Show-Global-Glyph
+git clone https://github.com/Nevu/Show-Global-Glyph.git nevu_ShowGlobalGlyphs
+cd nevu_ShowGlobalGlyphs
 printf '*.vfbak\n*.pyc\n.DS_Store\nREADME.*\nLICENSE.*\n.gitignore\n*.vdiff\nLICENSE\n*png\n' > .gitignore
 printf '*/5 * * * * app cd '$(pwd)' && git fetch -q --all -p\n' >> /tmp/GlyphsScriptsConfi/sync_git_repos
 cd ~/Library/Application\ Support/Glyphs/Plugins/
-ln -s ~/Documents/GlyphsScripts/Nevu_Plugins/Show-Global-Glyph/GlobalGlyph.glyphsReporter GlobalGlyph.glyphsReporter
+ln -s ~/Documents/GlyphsScripts/nevu_ShowGlobalGlyphs/GlobalGlyph.glyphsReporter GlobalGlyph.glyphsReporter
 cd ~/Documents/GlyphsScripts/
 echo '================================'
 echo 'Done Nevu ShowGlobalGlyph Plugin'


### PR DESCRIPTION
This fixes a problem where an alias was created for the plugin, but did not point to anything. 

![image](https://cloud.githubusercontent.com/assets/1435638/12534562/e9483c16-c2ae-11e5-884d-79580ef6e86f.png)

This now puts the plugin in the correct location and creates a working alias. I tested the code locally and its working.
